### PR TITLE
Support QT 6.7

### DIFF
--- a/qeframeworkSup/project/widgets/QERecipe/QERecipe.cpp
+++ b/qeframeworkSup/project/widgets/QERecipe/QERecipe.cpp
@@ -270,7 +270,7 @@ void QERecipe::setRecipeFile(QString pValue)
    {
       data = file->readAll();
       file->close();
-      flag = document.setContent(data);
+      flag = static_cast<bool>(document.setContent(data));
    }
    else
    {

--- a/qeframeworkSup/project/widgets/QEScript/QEScript.cpp
+++ b/qeframeworkSup/project/widgets/QEScript/QEScript.cpp
@@ -465,7 +465,7 @@ void QEScript::setScriptFile(QString pValue)
       {
          data = file->readAll();
          file->close();
-         flag = document.setContent(data);
+         flag = static_cast<bool>(document.setContent(data));
       }
       else
       {
@@ -498,7 +498,7 @@ void QEScript::setScriptText(QString pValue)
    if (scriptType == QE::SourceText)
    {
       document.clear();
-      if (document.setContent(scriptText) == false)
+      if (static_cast<bool>(document.setContent(scriptText)) == false)
       {
          rootElement = document.createElement("epicsqt");
          document.appendChild(rootElement);

--- a/qeframeworkSup/project/widgets/QEWidget/QEEmitter.cpp
+++ b/qeframeworkSup/project/widgets/QEWidget/QEEmitter.cpp
@@ -115,7 +115,7 @@ void QEEmitter::emitDbConnectionChanged (const unsigned int variableIndex)
    //
    if (this->filter [fkConnected]) {
       isConnected = qca->getChannelIsConnected ();
-      QGenericArgument arg = QGenericArgument (Q_ARG (bool, isConnected));
+      auto arg = Q_ARG (bool, isConnected);
       meta->invokeMethod (this->owner, member, Qt::DirectConnection, arg);
    }
 }
@@ -182,7 +182,7 @@ void QEEmitter::emitDbValueChangedPrivate (const bool useFormmattedText,
    if (okay && this->filter [fkDouble]) {
       // Good to go - create required argument.
       //
-      QGenericArgument arg = QGenericArgument (Q_ARG (double, dValue));
+      auto arg = Q_ARG (double, dValue);
 
       meta->invokeMethod (this->owner, member, Qt::DirectConnection, arg);
    }
@@ -191,25 +191,25 @@ void QEEmitter::emitDbValueChangedPrivate (const bool useFormmattedText,
    //
    if (okay && this->filter [fkBool]) {
       const bool bValue = (dValue != 0.0);
-      QGenericArgument arg = QGenericArgument (Q_ARG (bool, bValue));
+      auto arg = Q_ARG (bool, bValue);
       meta->invokeMethod (this->owner, member, Qt::DirectConnection, arg);
    }
 
    const int iValue = value.toInt (&okay);
    if (okay && this->filter [fkInt]) {
-      QGenericArgument arg = QGenericArgument (Q_ARG (int, iValue));
+      auto arg = Q_ARG (int, iValue);
       meta->invokeMethod (this->owner, member, Qt::DirectConnection, arg);
    }
 
    if (okay && this->filter [fkLong]) {
       long lValue = (long) iValue;
-      QGenericArgument arg = QGenericArgument (Q_ARG (long, lValue));
+      auto arg = Q_ARG (long, lValue);
       meta->invokeMethod (this->owner, member, Qt::DirectConnection, arg);
    }
 
    const qlonglong llValue = value.toLongLong (&okay);
    if (okay && this->filter [fkLongLong]) {
-      QGenericArgument arg = QGenericArgument (Q_ARG (qlonglong, llValue));
+      auto arg = Q_ARG (qlonglong, llValue);
       meta->invokeMethod (this->owner, member, Qt::DirectConnection, arg);
    }
 
@@ -217,7 +217,7 @@ void QEEmitter::emitDbValueChangedPrivate (const bool useFormmattedText,
    //
    const QString sValue = useFormmattedText ? formattedText : value.toString ();
    if (this->filter [fkString]) {
-      QGenericArgument arg = QGenericArgument (Q_ARG (QString, sValue));
+      auto arg = Q_ARG (QString, sValue);
       meta->invokeMethod (this->owner, member, Qt::DirectConnection, arg);
    }
 }


### PR DESCRIPTION
There were a few breaking changes in QT 6.5 that prevented qeframework from building on newer versions of QT 6.

These changes allow qeframework to build successfully on QT 6.7 but also remain compatible with QT versions < 6.5.

See commit messages for more specific details on the changes.

Build smoke tested on:
QT 5.15 :heavy_check_mark: 
QT 6.4 :heavy_check_mark: 
QT 6.7 :heavy_check_mark: 